### PR TITLE
Use the SDK runtime

### DIFF
--- a/org.gnome.Devhelp.json
+++ b/org.gnome.Devhelp.json
@@ -1,7 +1,7 @@
 {
     "app-id": "org.gnome.Devhelp",
     "runtime": "org.gnome.Sdk",
-    "runtime-version": "41",
+    "runtime-version": "42",
     "sdk": "org.gnome.Sdk",
     "command": "devhelp",
     "finish-args": [

--- a/org.gnome.Devhelp.json
+++ b/org.gnome.Devhelp.json
@@ -1,6 +1,6 @@
 {
     "app-id": "org.gnome.Devhelp",
-    "runtime": "org.gnome.Platform",
+    "runtime": "org.gnome.Sdk",
     "runtime-version": "41",
     "sdk": "org.gnome.Sdk",
     "command": "devhelp",


### PR DESCRIPTION
Usually apps should depend on the platform runtime rather than
the SDK, but it's the latter that includes API documentation,
so it makes sense to make an exception.

Devhelp's nightly builds are already doing that.

Close #13
