### PR TITLE
Add org.gnome.Sdk.Docs extension

### DIFF
--- a/org.gnome.Devhelp.json
+++ b/org.gnome.Devhelp.json
@@ -3,7 +3,7 @@
     "runtime": "org.gnome.Sdk",
     "runtime-version": "44",
     "sdk": "org.gnome.Sdk",
-    "sdk-extensions": [
+    "runtime-extensions": [
         "org.gnome.Sdk.Docs"
     ],
     "command": "devhelp",

--- a/org.gnome.Devhelp.json
+++ b/org.gnome.Devhelp.json
@@ -3,6 +3,9 @@
     "runtime": "org.gnome.Sdk",
     "runtime-version": "44",
     "sdk": "org.gnome.Sdk",
+    "sdk-extensions": [
+        "org.gnome.Sdk.Docs"
+    ],
     "command": "devhelp",
     "finish-args": [
         "--share=ipc",
@@ -20,7 +23,7 @@
         "share/man",
         "*.a"
     ],
-    "modules" : [
+    "modules": [
         {
             "name": "devhelp",
             "buildsystem": "meson",


### PR DESCRIPTION
Partially resolves https://github.com/flathub/org.gnome.Devhelp/issues/13#issuecomment-1399242051

The Sdk extension doesn't get installed automatically so that needs a separate issue somewhere (will investigate)