### PR TITLE
Document how to get documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,31 @@
+# DevHelp
+
+DevHelp doesn't come with documentation.
+
+You can install documentation from your package manager or from Flatpak.
+
+## Package managers
+
+DevHelp will automatically find and watch for documentation installed on the host.
+
+Fedora example
+
+```sh
+sudo dnf install gtk4-devel-docs glib2-doc libadwaita-doc libportal-devel-doc libsoup3-doc  webkitgtk6.0-doc
+```
+
+Ubuntu example
+
+```sh
+sudo apt install libgtk-4-doc libglib2.0-doc libadwaita-1-doc libportal-doc
+```
+
+## Flatpak
+
+You must install the documentation corresponding to the DevHelp runtime version.
+
+```sh
+flatpak info org.gnome.Devhelp
+flatpak install org.gnome.Sdk.Docs//44
+flatpak run --nofilesystem=host org.gnome.Devhelp
+```

--- a/org.gnome.Devhelp.json
+++ b/org.gnome.Devhelp.json
@@ -1,5 +1,5 @@
 {
-    "app-id": "org.gnome.Devhelp",
+    "id": "org.gnome.Devhelp",
     "runtime": "org.gnome.Sdk",
     "runtime-version": "44",
     "sdk": "org.gnome.Sdk",
@@ -20,7 +20,7 @@
         "share/man",
         "*.a"
     ],
-    "modules" : [
+    "modules": [
         {
             "name": "devhelp",
             "buildsystem": "meson",


### PR DESCRIPTION
`org.gnome.Sdk` doesn't come with documentation anymore
It's been split into `org.gnome.Sdk.Docs`. 

Even if we added `org.gnome.Sdk.Docs` as an sdk extension it wouldn't be installed automatically. Plus, in the flatpak world it's probably best to choose the version explicitely.

Ultimately I think "Install GNOME documentation" should be supported by DevHelp somehow but until then, let's document how to do this.