### PR TITLE
Mark DevHelp as EOL

### DIFF
--- a/flathub.json
+++ b/flathub.json
@@ -1,0 +1,3 @@
+{
+    "end-of-life": "This application is no longer maintained, and the associated source code repository appears to have been archived by the developers."
+}


### PR DESCRIPTION
> This project is archived. Its data is read-only. 

See: https://gitlab.gnome.org/Archive/devhelp